### PR TITLE
Sleep for 5 seconds after injection

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -1,7 +1,7 @@
 #include "hooks.hpp"
 
 DWORD WINAPI MainThread(LPVOID param) {
-
+	Sleep(5000);
 	AllocConsole();
 	FILE* Dummy;
 	freopen_s(&Dummy, "CONOUT$", "w", stdout);


### PR DESCRIPTION
this is a stupid hack to avoid running too fast and not being able to use UE functions if the DLL is being loaded directly at process start