### PR TITLE
Lock AllocConsole behind FESTNET_DEBUG environment variable on Release builds

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -1,11 +1,21 @@
 #include "hooks.hpp"
 
 DWORD WINAPI MainThread(LPVOID param) {
+	// sleep 5 seconds so UE can prepare itself (if we load at process start rather than post-launch injection)
 	Sleep(5000);
-	AllocConsole();
-	FILE* Dummy;
-	freopen_s(&Dummy, "CONOUT$", "w", stdout);
-	freopen_s(&Dummy, "CONIN$", "r", stdin);
+
+	// in Release builds check env variable FESTNET_DEBUG to see if we should enable the console
+	// the console causes issues in gamescope
+#ifdef NDEBUG
+	if (GetEnvironmentVariableA("FESTNET_DEBUG", NULL, 0) != 0) {
+#endif
+		AllocConsole();
+		FILE* Dummy;
+		freopen_s(&Dummy, "CONOUT$", "w", stdout);
+		freopen_s(&Dummy, "CONIN$", "r", stdin);
+#ifdef NDEBUG
+	}
+#endif
 
 	uintptr_t BaseAddress = reinterpret_cast<uintptr_t>(GetModuleHandle(0));
 


### PR DESCRIPTION
mostly doing this because Wine/Proton gets confused on Steam Deck on whether to display the game window or the console window, but also when logs are moving fast frametimes suffer - ideally nothing in the logs needs to be read when not doing debugging (and it can be enabled by running `set FESTNET_DEBUG=true` before launching FortniteLauncher.exe, or setting it system-wide if the command prompt is scary)

Debug builds will work the same as they do now